### PR TITLE
Permissions update

### DIFF
--- a/bot/command.py
+++ b/bot/command.py
@@ -185,8 +185,8 @@ class SetupCommand(Command):
         await categories[DMZ_category].set_permissions(everyone_role, overwrite=add_read)
         await all_channels[DMZ_category]["text"][auth_room_name].set_permissions(ta_role, overwrite=remove_read)
         await all_channels[DMZ_category]["text"][auth_room_name].set_permissions(student_role, overwrite=remove_read)
-        await all_channels[DMZ_category]["landing-pad"][auth_room_name].set_permissions(ta_role, overwrite=remove_read)
-        await all_channels[DMZ_category]["landing-pad"][auth_room_name].set_permissions(student_role, overwrite=remove_read)
+        await all_channels[DMZ_category]["text"]["landing-pad"].set_permissions(ta_role, overwrite=remove_read)
+        await all_channels[DMZ_category]["text"]["landing-pad"].set_permissions(student_role, overwrite=remove_read)
 
         logger.info("Updating channel authority with UUIDs {} and {}".format(waiting_room.id, queue_room.id))
         channel_authority: ChannelAuthority = ChannelAuthority(self.guild)


### PR DESCRIPTION
small alterations to permissions ordering (i generally followed admin->ta->student->unauthed)

changed permission settings for students and TAs in terms of seeing the authentication room and the landing pad

revoked media posting privileges for students in all channels except #memes

added ta_permissions in areas of code where it was missing