### PR TITLE
fixing mongodb for bot setup, fixing embed_links typo

### DIFF
--- a/bot/channels.py
+++ b/bot/channels.py
@@ -49,12 +49,14 @@ class ChannelAuthority:
         except KeyError:
             logger.warning("Unable to load channel authority!  Run setup!")
 
-    def save_channels(self, waiting_channel, queue_channel, auth_channel) -> None:
+    def save_channels(self, bulletin_category, waiting_channel, queue_channel, auth_channel) -> None:
+        self.bulletin_category = bulletin_category
         self.waiting_channel = waiting_channel
         self.queue_channel = queue_channel
         self.auth_channel = auth_channel
         collection = mongo.db[self.__CHANNEL_COLLECTION]
         document = {
+            self.__BULLETIN_CHANNEL_KEY: self.bulletin_category.id,
             self.__WAITING_CHANNEL_KEY: self.waiting_channel.id,
             self.__QUEUE_CHANNEL_KEY: self.queue_channel.id,
             self.__AUTH_CHANNEL_KEY: self.auth_channel.id,

--- a/bot/command.py
+++ b/bot/command.py
@@ -164,8 +164,8 @@ class SetupCommand(Command):
                 everyone_role = role
         remove_read: PermissionOverwrite = PermissionOverwrite(read_messages=False)
         add_read: PermissionOverwrite = PermissionOverwrite(read_messages=True)
-        remove_media: PermissionOverwrite = PermissionOverwrite(attach_files=False, embed_link=False)
-        add_media: PermissionOverwrite = PermissionOverwrite(attach_files=True, embed_link=True)
+        remove_media: PermissionOverwrite = PermissionOverwrite(attach_files=False, embed_links=False)
+        add_media: PermissionOverwrite = PermissionOverwrite(attach_files=True, embed_links=True)
         # Overwrite Instructor's Area category read permissions
         await categories[staff_category].set_permissions(admin_role, overwrite=add_read)
         await categories[staff_category].set_permissions(ta_role, overwrite=add_read)
@@ -190,7 +190,7 @@ class SetupCommand(Command):
 
         logger.info("Updating channel authority with UUIDs {} and {}".format(waiting_room.id, queue_room.id))
         channel_authority: ChannelAuthority = ChannelAuthority(self.guild)
-        channel_authority.save_channels(waiting_room, queue_room, auth_room)
+        channel_authority.save_channels(categories[DMZ_category], waiting_room, queue_room, auth_room)
 
         await first.send("Righto! You're good to go, boss!")
 
@@ -224,7 +224,7 @@ class SetupCommand(Command):
                                    connect=True,
                                    speak=True,
                                    use_voice_activation=True,
-                                   embed_link=True,
+                                   embed_links=True,
                                    attach_files=True)
         admin_permissions: Permissions = Permissions.all()
         un_authed_permissions: Permissions = Permissions.none()
@@ -405,7 +405,7 @@ class AcceptStudent(Command):
         session_category: CategoryChannel = await self.guild.create_category_channel(
             "Session for {}".format(name(session.member)),
             overwrites={
-                role: PermissionOverwrite(read_messages=True), #, attach_files=True, embed_link=True),
+                role: PermissionOverwrite(read_messages=True, attach_files=True, embed_links=True),
                 ra.student: PermissionOverwrite(read_messages=False),
                 ra.un_authenticated: PermissionOverwrite(read_messages=False)
             })


### PR DESCRIPTION
Reinstated the line change from #23, as well as changed all permission-related strings 'embed_link' to 'embed_links' (this was tested for both accepting queues and setting up, to ensure the bot recognized 'embed_links')

Line 193 of command.py now passes the Bulletin Board channel to save as ChannelAuthority's bulletin_category member variable. Assignment changes were reflected in lines 53 and 59 of channels.py. 
This was due to line 45 in channels.py, which required the mongo database to contain a document "bulletin", which was not assigned on server setup, throwing a KeyError.