### PR TITLE
Display position in queue to the student, if available.

### DIFF
--- a/bot/queues.py
+++ b/bot/queues.py
@@ -93,7 +93,8 @@ class QueueAuthority:
                          announcement=message,
                          ta=ta)
 
-    def is_member_in_queue(self, member: Member):
+    # Return the position of the member in the queue. Returns -1 if not found.
+    def get_queue_position_of(self, member: Member):
         collection = mongo.db[self.__QUEUE_COLLECTION]
         document = collection.find_one()
         if not document:
@@ -103,11 +104,13 @@ class QueueAuthority:
             }
             collection.insert(document)
 
+        position = 0
         for queue_item in document["queue"]:
             if queue_item[self.__MEMBER_ID_FIELD] == member.id:
-                return True
+                return position
+            position += 1
 
-        return False
+        return -1
 
     def retrieve_queue(self):
         collection = mongo.db[self.__QUEUE_COLLECTION]


### PR DESCRIPTION
When students type !status or !request, if they are in the queue, it will inform them which position they are in. 

I've renamed the `QueueAuthority#is_member_in_queue() method` to `get_queue_position_of()` which will return `-1` if the provided member isn't in the queue, otherwise the index of their position.