### PR TITLE
new ta queue for opening and closing office hours

### DIFF
--- a/bot/command.py
+++ b/bot/command.py
@@ -606,10 +606,14 @@ class EndOHSession(Command):
         return False
 
 
-async def is_oh_command(client, message, type):
+async def is_oh_command(client, message, types):
     ca: ChannelAuthority = ChannelAuthority(message.guild)
+    has_command = False
+    for type in types:
+        if type in message.content.lower():
+            has_command = True
     if is_bot_mentioned(message, client) and \
-            ("oh" in message.content.lower() and type in message.content.lower()):
+            ("oh" in message.content.lower() and has_command):
         if message.channel == ca.queue_channel:
             ra: RoleAuthority = RoleAuthority(message.guild)
             if ra.ta_or_higher(message.author):
@@ -619,7 +623,7 @@ async def is_oh_command(client, message, type):
                 return False
         else:
             await message.channel.send("You have to be in " +
-                                       ca.queue_channel.mention + " to {} office hours.".format(type))
+                                       ca.queue_channel.mention + " to {} office hours.".format(types))
             return False
     return False
 
@@ -643,7 +647,7 @@ class StartOfficeHours(Command):
 
     @staticmethod
     async def is_invoked_by_message(message: Message, client: Client):
-        return await is_oh_command(client, message, "start")
+        return await is_oh_command(client, message, ["start", "open"])
 
 
 @command_class
@@ -667,7 +671,7 @@ class EndOfficeHours(Command):
 
     @staticmethod
     async def is_invoked_by_message(message: Message, client: Client):
-        return await is_oh_command(client, message, "end")
+        return await is_oh_command(client, message, ["end", "close"])
 
 
 @command_class

--- a/bot/queues.py
+++ b/bot/queues.py
@@ -206,11 +206,13 @@ class QueueAuthority:
                 "open": True,
             }
             collection.insert(document)
-        
+        if "available_tas" not in document:
+            document["available_tas"] = []
         # Check if this is a new queue beginning and if new TA queueing
         fresh_start, is_new_ta = False, False
         if document["open"]:
             # Only check existing TA if open
+
             if ta_uid not in document["available_tas"]:
                 document["available_tas"].append(ta_uid)
                 is_new_ta = True
@@ -235,14 +237,14 @@ class QueueAuthority:
                 "open": False,
             }
             collection.insert(document)
-        
+
         was_removed = False
         tas = len(document["available_tas"])
         if ta_uid in document["available_tas"]:
             document["available_tas"].remove(ta_uid)
             was_removed = True
             tas -= 1
-            
+
         collection.replace_one({"_id": document["_id"]}, document)
         return document["open"], was_removed, tas
 


### PR DESCRIPTION
**command.py**
```
EndOfficeHours:
  Closing office hours is simple, anyone can try to close it. 
  The closure simply removes the TA from duty if they are in the list. 
  If the TA does not exist in the list, the list does not change, but the list length still gets returned. 
  Therefore, if there was ever an error in which the available_tas list is empty during open office hours, anyone may close the queue.
  Also, closing the queue entirely (no TAs on duty) now deletes all of the request announcements in student-requests.
```

```
StartOfficeHours:
  Anyone who opens office hours will be added to the list of available TAs. 
  Given that a queue is already open, the bot will not send an "opening" message to the waiting-room multiple times.
```

```
AcceptStudent:
  TAs must be on duty to accept requests and open office hour sessions.
```

```
RejectStudent:
  No changes were made, but just noting that any TA will be able to do a quick answer through rejection, regardless of being in the TA list.
```

```
EndOHSession:
  No changes were made, but just noting that any TA will be able to end an office hour session, regardless of being in the TA list.
  This is useful in a specific case where a TA may fully close office hours while doing their last session.
```


**queues.py**
_Added available_tas as a List to the queue document._
```
remove_all():
  Now removes all request announcement messages
```

```
open_office_hours():
  Now returns a bool value which indicates whether a new queue is being opened.
  Also returns a bool value which indicates whether the opening TA is a new TA to the list.
  A newly opened queue is initialized with a List of size 1 containing the starting TA's user id.
  A previously existing queue will simply append the new TA's user id.
```

```
close_office_hours(): #New
  Returns two bool values for whether the TA was successfully removed and if the office hours were open upon close attempt
  Returns an integer value for how many TAs are marked on duty.
  Removes the TA's id from the available_tas list if existing. Return value determines whether office hours close entirely.
```

```
is_ta_on_duty(): #New
  Simply returns a bool value indicating whether a TA is in the available_tas list.
```