### PR TITLE
Fixed Issue #46

### DIFF
--- a/bot/command/accept.py
+++ b/bot/command/accept.py
@@ -41,7 +41,7 @@ class AcceptStudent(command.Command):
             overwrites={
                 role: PermissionOverwrite(read_messages=True, attach_files=True, embed_links=True),
                 ra.student: PermissionOverwrite(read_messages=False),
-                ra.un_authenticated: PermissionOverwrite(read_messages=False)
+                ra.everyone: PermissionOverwrite(read_messages=False)
             })
         text_channel: TextChannel = await session_category.create_text_channel("Text Cat")
         await session_category.create_voice_channel("Voice chat")

--- a/bot/command/accept.py
+++ b/bot/command/accept.py
@@ -41,6 +41,7 @@ class AcceptStudent(command.Command):
             overwrites={
                 role: PermissionOverwrite(read_messages=True, attach_files=True, embed_links=True),
                 ra.student: PermissionOverwrite(read_messages=False),
+                ra.ta_or_higher: PermissionOverwrite(read_messages=True),
                 ra.everyone: PermissionOverwrite(read_messages=False)
             })
         text_channel: TextChannel = await session_category.create_text_channel("Text Cat")

--- a/bot/command/accept.py
+++ b/bot/command/accept.py
@@ -41,7 +41,8 @@ class AcceptStudent(command.Command):
             overwrites={
                 role: PermissionOverwrite(read_messages=True, attach_files=True, embed_links=True),
                 ra.student: PermissionOverwrite(read_messages=False),
-                ra.ta_or_higher: PermissionOverwrite(read_messages=True),
+                ra.ta: PermissionOverwrite(read_messages=True),
+                ra.admin: PermissionOverwrite(read_messages=True),
                 ra.everyone: PermissionOverwrite(read_messages=False)
             })
         text_channel: TextChannel = await session_category.create_text_channel("Text Cat")


### PR DESCRIPTION
"server members with no roles can join 1-on-1 OH sessions"
By changing the "read messages" category permission for the role @everyone, this should ensure that only the respective student, and all TAs and professors can view the office hour session.